### PR TITLE
Fixed the overlapping between the placeholder and the label name on the main contact form, on the contact page

### DIFF
--- a/embellish-website/css/styles.css
+++ b/embellish-website/css/styles.css
@@ -156,6 +156,15 @@ button {
   margin-bottom: 0 !important;
 }
 
+/* fixed the overlapping of label and placeholder, the placeholder appears only after clicking the input field */
+
+.form-control::placeholder {
+  opacity: 0;
+}
+.form-control:focus::placeholder {
+opacity: 1;
+}
+
 @media only screen and (max-width: 600px) {
   .grid-container{
     grid-template-columns: repeat(1, 1fr);


### PR DESCRIPTION

## What is the change?
Removed the overlapping between the placeholder and the label name in the input field of the contact form.

## Related issue?
closes: #250

## How was it tested?
Tested in a browser, refreshed several times.

## Checklist:
Before you create this PR, confirm all the requirements listed below by checking the checkboxes `[x]`:

-   [x] Have you followed the [Contribution Guidelines](https://github.com/siddhi-244/Embellish/blob/46893695e5f28da0b0f928ae614b262239351d31/CONTRIBUTING.md)while contributing.
-   [x] Have you checked there aren't other open [Pull Requests](https://github.com/siddhi-244/Embellish/pulls) for the same update/change?
-   [ ] Have you made corresponding changes to the documentation?
-   [x] Have you tested the code before submission?
-   [x] Have you formatted your code ? (You can use any html,css beautifier)
-   [x] My changes generates no new warnings.
-   [ ] I'm OpenCode contributor.
-   [x] I have commented my code, particularly in hard-to-understand areas.


## GIF/video of the working of component:
![fixed](https://user-images.githubusercontent.com/84074575/165503244-88e0fdff-fde6-4bed-ab74-2bdaa33b60a6.gif)

I hope I made changes to the right file!