### PR TITLE
Footer copyright year updated

### DIFF
--- a/embellish-website/include/footer.html
+++ b/embellish-website/include/footer.html
@@ -2,7 +2,7 @@
      <div class="container px-5">
           <div class="row align-items-center justify-content-between flex-column flex-sm-row">
                <div class="col-auto">
-                    <div class="small m-0 text-white">&copy; Embellish 2021</div>
+                    <div class="small m-0 text-white">&copy; Embellish 2023</div>
                </div>
                <div class="col-auto">
                     <a class="link-light small" href="./about.html">About Us</a>


### PR DESCRIPTION
## What is the change?
Footer copyright year updated

![image](https://user-images.githubusercontent.com/98512995/216273207-3710d6f5-e35e-44e3-ac49-b8559a60235b.png)


## Checklist:

-   [x] Have you followed the [Contribution Guidelines](https://github.com/siddhi-244/Embellish/blob/46893695e5f28da0b0f928ae614b262239351d31/CONTRIBUTING.md)while contributing.
-   [x] Have you checked there aren't other open [Pull Requests](https://github.com/siddhi-244/Embellish/pulls) for the same update/change?
-   [x] Have you made corresponding changes to the documentation?
-   [x] Have you tested the code before submission?
-   [x] Have you formatted your code ? (You can use any html,css beautifier)
-   [x] My changes generates no new warnings.
-   [x] I'm Diversion2k23 contributor.
-   [x] I have commented my code, particularly in hard-to-understand areas.
